### PR TITLE
dev: Fix pr-check for sdist

### DIFF
--- a/pr-check.sh
+++ b/pr-check.sh
@@ -90,6 +90,8 @@ fi
 if git ls-files --error-unmatch pr-check.sh 2> /dev/null
 then
     git clean -Xf .
+else
+    sdist_mode="--sdist-mode"
 fi
 
 venv=$(mktemp -u brainiak_pr_venv_XXXXX) || \
@@ -118,7 +120,7 @@ python3 -m pip install $ignore_installed -U -r requirements-dev.txt || \
     exit_with_error_and_venv "run-checks failed"
 
 # run tests
-./run-tests.sh || \
+./run-tests.sh $sdist_mode || \
     exit_with_error_and_venv "run-tests failed"
 
 # build documentation

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -16,7 +16,13 @@
 
 set -e
 
-python3 -m pip freeze | grep -qi /brainiak || {
+# When installing from sdist, the pip freeze output cannot be used to
+# detect editable mode. Use the "--sdist-mode" flag.
+sdist_mode=$1
+
+python3 -m pip freeze | grep -qi /brainiak \
+        || [ ${sdist_mode:-default} = "--sdist-mode" ] \
+        || {
     echo "You must install brainiak in editable mode"`
         `" before calling "$(basename "$0")
     exit 1


### PR DESCRIPTION
Currently, pr-check fails when calling run-tests in an sdist directory
because of the editable install detection.

Note that editable install detection is there to minimize testing errors
during development, i.e., the developer testing the checked out code
while having a different version installed.