### PR TITLE
Fixing numerical issue and adding utility function

### DIFF
--- a/docs/newsfragments/292.feature
+++ b/docs/newsfragments/292.feature
@@ -1,0 +1,2 @@
+eventseg: Fixed numerical instability bug, added utility function for weighted variance
+

--- a/tests/eventseg/test_event.py
+++ b/tests/eventseg/test_event.py
@@ -49,3 +49,28 @@ def test_event_transfer():
     events = np.argmax(seg, axis=1)
     assert np.array_equal(events, [0, 0, 0, 1, 1, 1, 1]),\
         "Failed to correctly transfer two events to new data"
+
+
+def test_weighted_var():
+    es = brainiak.eventseg.event.EventSegment(2)
+
+    D = np.zeros((8, 4))
+    for t in range(4):
+        D[t, :] = (1/np.sqrt(4/3)) * np.array([-1, -1, 1, 1])
+    for t in range(4, 8):
+        D[t, :] = (1 / np.sqrt(4 / 3)) * np.array([1, 1, -1, -1])
+    mean_pat = D[[0, 4], :].T
+
+    weights = np.zeros((8, 2))
+    weights[:, 0] = [1, 1, 1, 1, 0, 0, 0, 0]
+    weights[:, 1] = [0, 0, 0, 0, 1, 1, 1, 1]
+    assert np.array_equal(
+        es.calc_weighted_event_var(D, weights, mean_pat), [0, 0]),\
+        "Failed to compute variance with 0/1 weights"
+
+    weights[:, 0] = [1, 1, 1, 1, 0.5, 0.5, 0.5, 0.5]
+    weights[:, 1] = [0.5, 0.5, 0.5, 0.5, 1, 1, 1, 1]
+    true_var = (4 * 0.5 * 12)/(6 - 5/6) * np.ones(2) / 4
+    assert np.allclose(
+        es.calc_weighted_event_var(D, weights, mean_pat), true_var),\
+        "Failed to compute variance with fractional weights"

--- a/tests/eventseg/test_event.py
+++ b/tests/eventseg/test_event.py
@@ -31,7 +31,7 @@ def test_fit_shapes():
 
 
 def test_simple_boundary():
-    es = brainiak.eventseg.event.EventSegment(2, n_iter=10)
+    es = brainiak.eventseg.event.EventSegment(2)
     sample_data = np.asarray([[1, 1, 1, 0, 0, 0, 0], [0, 0, 0, 1, 1, 1, 1]])
     es.fit(sample_data.T)
 


### PR DESCRIPTION
Changed the transition probability to scale with the number of timepoints, which should not change the solution (all valid paths have the same number of transitions) but gives better numerical stability. Also, added a utility function for computing weighted variance, which will be useful for the notebooks I'll be releasing in the future for the Schema project.