### PR TITLE
add sanity check of input arguments in FCMA examples

### DIFF
--- a/examples/fcma/classification.py
+++ b/examples/fcma/classification.py
@@ -148,6 +148,10 @@ def example_of_correlating_two_components_aggregating_sim_matrix(raw_data, raw_d
 
 # python3 classification.py face_scene bet.nii.gz face_scene/prefrontal_top_mask.nii.gz face_scene/fs_epoch_labels.npy
 if __name__ == '__main__':
+    if len(sys.argv) != 5:
+        logger.error('the number of input argument is not correct')
+        sys.exit(1)
+
     data_dir = sys.argv[1]
     extension = sys.argv[2]
     mask_file = sys.argv[3]

--- a/examples/fcma/corr_comp.py
+++ b/examples/fcma/corr_comp.py
@@ -29,6 +29,10 @@ logger = logging.getLogger(__name__)
 
 # python3 corr_comp.py face_scene bet.nii.gz face_scene/prefrontal_top_mask.nii.gz face_scene/fs_epoch_labels.npy
 if __name__ == '__main__':
+    if len(sys.argv) != 5:
+        logger.error('the number of input argument is not correct')
+        sys.exit(1)
+
     data_dir = sys.argv[1]
     extension = sys.argv[2]
     mask_file = sys.argv[3]

--- a/examples/fcma/mvpa_classification.py
+++ b/examples/fcma/mvpa_classification.py
@@ -31,6 +31,10 @@ logger = logging.getLogger(__name__)
 
 # python3 mvpa_classification.py face_scene bet.nii.gz face_scene/visual_top_mask.nii.gz face_scene/fs_epoch_labels.npy
 if __name__ == '__main__':
+    if len(sys.argv) != 5:
+        logger.error('the number of input argument is not correct')
+        sys.exit(1)
+
     data_dir = sys.argv[1]
     extension = sys.argv[2]
     mask_file = sys.argv[3]

--- a/examples/fcma/mvpa_voxel_selection.py
+++ b/examples/fcma/mvpa_voxel_selection.py
@@ -38,6 +38,10 @@ if __name__ == '__main__':
             'programming starts in %d process(es)' %
             MPI.COMM_WORLD.Get_size()
         )
+    if len(sys.argv) != 6:
+        logger.error('the number of input argument is not correct')
+        sys.exit(1)
+
     data_dir = sys.argv[1]
     suffix = sys.argv[2]
     mask_file = sys.argv[3]

--- a/examples/fcma/voxel_selection.py
+++ b/examples/fcma/voxel_selection.py
@@ -37,6 +37,9 @@ if __name__ == '__main__':
             'programming starts in %d process(es)' %
             MPI.COMM_WORLD.Get_size()
         )
+    if len(sys.argv) != 7:
+        logger.error('the number of input argument is not correct')
+        sys.exit(1)
     data_dir = sys.argv[1]
     suffix = sys.argv[2]
     mask_file = sys.argv[3]


### PR DESCRIPTION
check if the number of input arguments matches the expected number.