### PR TITLE
docs: Change docs link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,10 +149,7 @@ BrainIAK installation.
 Documentation
 =============
 
-The documentation is available at `pythonhosted.org/brainiak`_.
-
-.. _pythonhosted.org/brainiak:
-    https://pythonhosted.org/brainiak
+The documentation is available at http://brainiak.org/docs.
 
 
 Contributing


### PR DESCRIPTION
We moved the HTML docs to brainiak.org because pythonhosted.org does not
accept uploads anymore. See:
https://github.com/pypa/pypi-legacy/issues/672