### PR TITLE
Solves the failing test of SS-SRM

### DIFF
--- a/docs/newsfragments/304.trivial
+++ b/docs/newsfragments/304.trivial
@@ -1,0 +1,1 @@
+Solved an issue that test won't pass because of a missing evironment variable for Theano with MKL versions >=2018.

--- a/pr-check.sh
+++ b/pr-check.sh
@@ -125,7 +125,7 @@ python3 -m pip install $ignore_installed -U -r requirements-dev.txt || \
 
 # build documentation
 cd docs
-export THEANO_FLAGS='device=cpu,floatX=float64,blas.ldflags='
+export THEANO_FLAGS='device=cpu,floatX=float64,blas.ldflags=-lblas'
 
 if [ ! -z $SLURM_NODELIST ]
 then

--- a/pr-check.sh
+++ b/pr-check.sh
@@ -125,7 +125,7 @@ python3 -m pip install $ignore_installed -U -r requirements-dev.txt || \
 
 # build documentation
 cd docs
-export THEANO_FLAGS='device=cpu,floatX=float64'
+export THEANO_FLAGS='device=cpu,floatX=float64,blas.ldflags='
 
 if [ ! -z $SLURM_NODELIST ]
 then

--- a/pr-check.sh
+++ b/pr-check.sh
@@ -48,6 +48,9 @@ function create_conda_venv {
 
 function activate_conda_venv {
     source activate $1
+    # Pip may update setuptools while installing BrainIAK requirements and
+    # break the Conda cached package, which breaks subsequent runs.
+    conda install --yes -f setuptools
 }
 
 function deactivate_conda_venv {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -28,6 +28,9 @@ python3 -m pip freeze | grep -qi /brainiak \
     exit 1
 }
 
+# Define MKL env variable that is required by Theano to run with MKL 2018
+export MKL_THREADING_LAYER=GNU
+
 mpi_command=mpiexec
 if [ ! -z $SLURM_NODELIST ]
 then


### PR DESCRIPTION
This PR resolves an issue between Theano and MKL 2018 that requires an environment variable for MKL to run Theano.

Fixes #304 .