### PR TITLE
dev: Reinstall setuptools in Conda env

### DIFF
--- a/pr-check.sh
+++ b/pr-check.sh
@@ -48,6 +48,9 @@ function create_conda_venv {
 
 function activate_conda_venv {
     source activate $1
+    # Pip may update setuptools while installing BrainIAK requirements and
+    # break the Conda cached package, which breaks subsequent runs.
+    conda install --yes -f setuptools
 }
 
 function deactivate_conda_venv {


### PR DESCRIPTION
Addresses errors such as the one in PR #305.

If the PyPI version of setuptools is newer than the one in Conda and
backwards incompatible, the build process can break.

When used with the `-I` flag, `pip install` will overwrite the Conda
`pkgs` cache, which is used for creating new environments.