### PR TITLE
dev: Reduce number of Travis MacOS builds to 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,6 @@ matrix:
       before_install: &macos_before_install
         - brew install llvm mpich python3
 
-    - os: osx
-      osx_image: xcode8
-      language: generic
-      env: *macos_env
-      before_install: *macos_before_install
-
     # Build and test conda packages
     - os: linux
       dist: trusty


### PR DESCRIPTION
This reduced build time, frequently to half, because Travis has a limit
of 2 concurrent builds:
"After much painstaking deliberation, we have decided to limit the
concurrent macOS builds to a maximum of two out of the five offered."
https://blog.travis-ci.com/2017-09-22-macos-update

Fixes #332.