### PR TITLE
docs: Fix Conda channels in install instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,7 +10,7 @@ dependencies are not available in the default channels.
 
 Use our ``brainiak`` channel to install::
 
-    conda install -c brainiak brainiak
+    conda install -c brainiak -c defaults -c conda-forge brainiak
 
 Note that `~brainiak.funcalign.sssrm.SSSRM` currently uses Theano, which
 requires the Xcode Command Line Tools on `MacOS`_.


### PR DESCRIPTION
We already have this channel list in the README.