### PR TITLE
dev: Pin Python version in Conda build

### DIFF
--- a/.conda/bin/build
+++ b/.conda/bin/build
@@ -2,6 +2,12 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+python_version=$1
+if [ -z ${python_version+dummy} ]
+then
+    python_version=3.6
+fi
+
 export BRAINIAK_HOME=$DIR/../../
 
 # See run-tests.sh
@@ -15,4 +21,4 @@ then
     CONDA_HOME="$HOME"/miniconda3
 fi
 
-"$CONDA_HOME"/bin/conda build "$DIR"/..
+"$CONDA_HOME"/bin/conda build --python=$python_version "$DIR"/..

--- a/.conda/bin/build
+++ b/.conda/bin/build
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 python_version=$1
-if [ -z ${python_version+dummy} ]
+if [ -z "$python_version" ]
 then
     python_version=3.6
 fi
@@ -16,7 +16,7 @@ export MKL_THREADING_LAYER=GNU
 # See https://github.com/brainiak/brainiak/issues/377
 export KMP_DUPLICATE_LIB_OK=TRUE
 
-if [ -z ${CONDA_HOME+dummy} ]
+if [ -z "$CONDA_HOME" ]
 then
     CONDA_HOME="$HOME"/miniconda3
 fi


### PR DESCRIPTION
Conda packages for our dependencies lag behind Python releases. This
causes problems with Travis, e.g.:
https://travis-ci.org/brainiak/brainiak/jobs/435150784