### PR TITLE
dev: Fix Pip installation during Conda build

### DIFF
--- a/.conda/build.sh
+++ b/.conda/build.sh
@@ -9,7 +9,7 @@ fi
 echo $PREFIX
 
 # Install pymanopt via pip because there isn't a conda package
-$PYTHON -m pip install pymanopt
+PIP_NO_INDEX=False $PYTHON -m pip install pymanopt
 
 # NOTE: This is the recommended way to install packages
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt


### PR DESCRIPTION
Our dependency installation method was not supported anymore:
https://github.com/conda/conda-build/pull/3109

Note to self: read release notes first when debugging.