### PR TITLE
fmrisim: Fix numpy.matlib import

### DIFF
--- a/brainiak/utils/fmrisim.py
+++ b/brainiak/utils/fmrisim.py
@@ -81,6 +81,9 @@ from itertools import product
 from statsmodels.tsa.arima_model import ARMA
 import math
 import numpy as np
+# See pyflakes issue #248
+# https://github.com/PyCQA/pyflakes/issues/248
+import numpy.matlib  # noqa: F401
 from numpy.linalg import LinAlgError
 from pkg_resources import resource_stream
 from scipy import stats


### PR DESCRIPTION
Importing NumPy does not import the `matlib` module. It was implicitly
imported by SciPy, but this changed in SciPy version 1.2.0:
https://github.com/scipy/scipy/pull/9302/files#diff-99684e0fbbb74e008ca6a5c1196adf37