### PR TITLE
srm: subtract the subject-specific mean in .transform()

### DIFF
--- a/brainiak/funcalign/srm.py
+++ b/brainiak/funcalign/srm.py
@@ -260,7 +260,8 @@ class SRM(BaseEstimator, TransformerMixin):
         s = [None] * len(X)
         for subject in range(len(X)):
             if X[subject] is not None:
-                s[subject] = self.w_[subject].T.dot(X[subject])
+                s[subject] = self.w_[subject].T.dot(
+                    X[subject] - self.mu_[subject][:, np.newaxis])
 
         return s
 


### PR DESCRIPTION
This is a fix described in #406 . With @cameronphchen 's fix, SRM can align two trajectories that differ by a vector shift by using the estimated `mu`. 