### PR TITLE
dev: Workaround for Theano NumPy incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
         'cython',
         'mpi4py',
         'nitime',
-        'numpy',
+        'numpy<1.16',  # See https://github.com/Theano/Theano/pull/6671
         'scikit-learn[alldeps]>=0.18',
         'scipy!=1.0.0',  # See https://github.com/scipy/scipy/pull/8082
         'statsmodels',


### PR DESCRIPTION
Theano is not compatible with NumPy>=1.16. A fix exists, but it is not
yet part of a release. See:
https://github.com/Theano/Theano/pull/6671

As a workaround until the next Theano release, we can pin the NumPy
version we use, similar to Keras:
https://github.com/keras-team/keras/pull/12037