### PR TITLE
dev: Remove superseded workaround from PR #408

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,12 +124,12 @@ setup(
         'cython',
         'mpi4py',
         'nitime',
-        'numpy<1.16',  # See https://github.com/Theano/Theano/pull/6671
+        'numpy',
         'scikit-learn[alldeps]>=0.18',
         'scipy!=1.0.0',  # See https://github.com/scipy/scipy/pull/8082
         'statsmodels',
         'pymanopt',
-        'theano',
+        'theano>=1.0.4',  # For NumPy>=1.16 compatibility
         'pybind11>=1.7',
         'psutil',
         'nibabel',


### PR DESCRIPTION
New Theano release works with NumPy>=1.16.