### PR TITLE
docs: Move PR #384 NEWS entry to newsfragments

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -17,8 +17,6 @@ Features
 - fmrisim: Added fitting procedure for SFNR and SNR parameters. Updated AR to
   be ARMA, involving both the generation and estimation. (`#372
   <https://github.com/brainiak/brainiak/pull/372>`_)
-- isc: Revamped ISC/ISFC functionality with more statistical tests. (`#384
-  <https://github.com/brainiak/brainiak/pull/384>`_)
 - reprsimil: Added an option in BRSA to set the prior of SNR to be "equal"
   across all voxels. (`#387
   <https://github.com/brainiak/brainiak/pull/387>`_)

--- a/docs/newsfragments/384.feature
+++ b/docs/newsfragments/384.feature
@@ -1,0 +1,1 @@
+isc: Revamped ISC/ISFC functionality with more statistical tests.


### PR DESCRIPTION
This will add it to the next release, not v0.8, as it should be.
In PR #405, I mistakenly suggested editing NEWS directly.