### PR TITLE
dev: Drop support for Python 3.4, add 3.6 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,17 @@ branches:
 matrix:
   include:
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       language: python
-      python: 3.4
+      python: 3.6
       addons: &linux_addons
         apt: &apt
           packages:
             - build-essential libgomp1 libmpich-dev mpich
 
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       language: python
       python: 3.5
@@ -36,7 +36,7 @@ matrix:
 
     # Build and test conda packages
     - os: linux
-      dist: trusty
+      dist: xenial
       install: ./.conda/bin/install-miniconda
       script: ./.conda/bin/build
 

--- a/brainiak/__init__.py
+++ b/brainiak/__init__.py
@@ -15,8 +15,8 @@
 
 import sys
 
-if sys.version_info < (3, 4):
+if sys.version_info < (3, 5):
     raise Exception(
-        "Please use Python version 3.4 or higher, "
+        "Please use Python version 3.5 or higher, "
         "lower versions are not supported"
     )

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,7 +21,7 @@ Source
 Requirements
 ============
 
-We support Linux and MacOS with Python version 3.4 or higher. Most of the
+We support Linux and MacOS with Python version 3.5 or higher. Most of the
 dependencies will be installed automatically. However, a few need to be
 installed manually.
 

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ import sys
 import setuptools
 from copy import deepcopy
 
-assert sys.version_info >= (3, 4), (
-    "Please use Python version 3.4 or higher, "
+assert sys.version_info >= (3, 5), (
+    "Please use Python version 3.5 or higher, "
     "lower versions are not supported"
 )
 
@@ -146,6 +146,6 @@ setup(
     cmdclass={'build_ext': BuildExt},
     packages=find_packages(),
     package_data={'brainiak.utils': ['grey_matter_mask.npy']},
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     zip_safe=False,
 )


### PR DESCRIPTION
Mypy dropped support for Python 3.4 in version 0.700. Technically, we
could separate the Python version in developer requirements from the
Python version in user requirements (where Mypy is not a dependency),
but I think that would complicate our setup too much.

Also switch to Ubuntu 16.04 for Travis testing, since support for 14.04
ends in April 2019.