### PR TITLE
Added matrix multiplication to ISC

### DIFF
--- a/brainiak/isc.py
+++ b/brainiak/isc.py
@@ -50,7 +50,6 @@ The implementation is based on the work in [Hasson2004]_, [Kauppi2014]_,
 import numpy as np
 import logging
 from scipy.spatial.distance import squareform
-from scipy.stats import pearsonr
 import itertools as it
 from brainiak.fcma.util import compute_correlation
 from brainiak.utils.utils import (phase_randomize, p_from_null,
@@ -166,14 +165,14 @@ def isc(data, pairwise=False, summary_statistic=None, tolerate_nans=True):
     elif not pairwise:
 
         # Preset array
-        iscs_stack = np.zeros((data.shape[2], data.shape[1])) 
+        iscs_stack = np.zeros((data.shape[2], data.shape[1]))
 
-        # Leave one out loop    
+        # Leave one out loop
         for s in range(data.shape[2]):
 
             # Get the individual and the average of the others
-            individual = data[:, :, s].T 
-            other = np.mean(np.delete(data, s, axis=2), axis=2).T
+            individual = data[:, :, s].T
+            other = mean(np.delete(data, s, axis=2), axis=2).T
 
             # Perform the row-wise correlation
             iscs_stack[s, :] = _corr_mat(individual, other)
@@ -469,11 +468,11 @@ def _check_targets_input(targets, data):
 
 def _corr_mat(mat_1, mat_2):
     """Computes matrix-wise correlation values for ISC
-    
-    This takes in as input two matrices of voxel by time and returns 
-    a correlation value for each voxel (ISC values). This is an efficient 
+
+    This takes in as input two matrices of voxel by time and returns
+    a correlation value for each voxel (ISC values). This is an efficient
     computation to perform correlations across many voxels
-    
+
     Parameters
     ----------
     mat_1 : 2D array
@@ -488,17 +487,17 @@ def _corr_mat(mat_1, mat_2):
         ISC values for every individual voxel
 
     """
-    
+
     if mat_1.shape != mat_2.shape:
         raise ValueError("Inputs are not the same shape, ISC not possible")
-    
+
     # Calculate the row means
-    mat_1_mean = np.reshape(np.mean(mat_1, axis=1),(mat_1.shape[0], 1))
-    mat_2_mean = np.reshape(np.mean(mat_2, axis=1),(mat_2.shape[0], 1))
-    
+    mat_1_mean = np.reshape(np.mean(mat_1, axis=1), (mat_1.shape[0], 1))
+    mat_2_mean = np.reshape(np.mean(mat_2, axis=1), (mat_2.shape[0], 1))
+
     # Calculate the mean difference in product
     sum_mean_diff = np.sum((mat_1 - mat_1_mean) * (mat_2 - mat_2_mean), axis=1)
-    
+
     # Calculate the SSE denominator
     mat_1_SSE = np.sum((mat_1 - mat_1_mean)**2, axis=1)
     mat_2_SSE = np.sum((mat_2 - mat_2_mean)**2, axis=1)

--- a/brainiak/isc.py
+++ b/brainiak/isc.py
@@ -151,7 +151,10 @@ def isc(data, pairwise=False, summary_statistic=None, tolerate_nans=True):
     if n_subjects == 2:
 
         # Perform analaysis on the two pairs
-        iscs_stack = _corr_mat(data[:, :, 0].T, data[:, :, 1].T).T
+        iscs_stack = _corr_mat(data[:, :, 0].T, data[:, :, 1].T)
+
+        # Reshape array to fit
+        iscs_stack = iscs_stack.reshape(1, n_voxels)
 
     elif pairwise:
 

--- a/brainiak/isc.py
+++ b/brainiak/isc.py
@@ -505,7 +505,7 @@ def _corr_mat(mat_1, mat_2):
 
     # Find r
     r = sum_mean_diff / denominator
-    
+
     return r
 
 

--- a/brainiak/isc.py
+++ b/brainiak/isc.py
@@ -151,7 +151,7 @@ def isc(data, pairwise=False, summary_statistic=None, tolerate_nans=True):
     if n_subjects == 2:
 
         # Perform analaysis on the two pairs
-        iscs_stack = _corr_mat(data[:, :, 0].T, data[:, :, 1].T)
+        iscs_stack = _corr_mat(data[:, :, 0].T, data[:, :, 1].T).T
 
     elif pairwise:
 

--- a/tests/isc/test_isc.py
+++ b/tests/isc/test_isc.py
@@ -153,6 +153,23 @@ def test_isc_output():
 
     logger.info("Finished testing ISC outputs")
 
+# Make sure that the corr_mat function works
+def test_isc_output():
+
+    logger.info("Testing _corr_mat")
+    
+    # How many voxels are there?
+    v = 100
+    
+    data = np.random.randn(200, v, 2)
+
+    # Perform the correlation
+    isc = corr_mat(data[:, :, 0].T, data[:, :, 1].T)
+    
+    # Check there are the right number of voxels in the output
+    assert len(isc) == v
+
+    logger.info("Finished testing _corr_mat")
 
 # Check for proper handling of NaNs in ISC
 def test_isc_nans():

--- a/tests/isc/test_isc.py
+++ b/tests/isc/test_isc.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 from brainiak.isc import (isc, isfc, bootstrap_isc, permutation_isc,
                           squareform_isfc, timeshift_isc,
-                          phaseshift_isc)
+                          phaseshift_isc, _corr_mat)
 from scipy.spatial.distance import squareform
 
 logger = logging.getLogger(__name__)

--- a/tests/isc/test_isc.py
+++ b/tests/isc/test_isc.py
@@ -153,23 +153,25 @@ def test_isc_output():
 
     logger.info("Finished testing ISC outputs")
 
+
 # Make sure that the corr_mat function works
-def test_isc_output():
+def test_corr_mat():
 
     logger.info("Testing _corr_mat")
-    
+
     # How many voxels are there?
     v = 100
-    
+
     data = np.random.randn(200, v, 2)
 
     # Perform the correlation
-    isc = corr_mat(data[:, :, 0].T, data[:, :, 1].T)
-    
+    isc = _corr_mat(data[:, :, 0].T, data[:, :, 1].T)
+
     # Check there are the right number of voxels in the output
     assert len(isc) == v
 
     logger.info("Finished testing _corr_mat")
+
 
 # Check for proper handling of NaNs in ISC
 def test_isc_nans():
@@ -962,6 +964,7 @@ if __name__ == '__main__':
     test_isc_input()
     test_isc_options()
     test_isc_output()
+    test_corr_mat()
     test_isc_nans()
     test_bootstrap_isc()
     test_permutation_isc()


### PR DESCRIPTION
Added matrix multiplication to ISC, rather than the looping through voxels. From testing it provides between x5 and x10 speed up. No changes were made to the pairwise analysis because I wasn't sure how to deal with squareform. A test was also added for the newly added _corr_mat function