### PR TITLE
dev: Add brainiak-tutorials to Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.pkl
 
 data
+tutorials
 
 brainiak.egg-info
 build

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -342,8 +342,9 @@ To make a release:
        anaconda upload -u brainiak \
        $CONDA_HOME/conda-bld/<OS>/brainiak-<v>-<python_version>.tar.bz2
 
-9. Build and push the Docker image::
+9. Build and push the Docker image (requires brainiak-tutorials checkout)::
 
+       cd tutorials && git pull --ff-only && cd -
        docker build --no-cache -t brainiak/brainiak .
        docker push brainiak/brainiak
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
+ARG DEBIAN_FRONTEND=noninteractive
 # Group 1 must be synced with README
 # Group 2 must be synced with requirements for examples
 # Group 3 must be synced with rest of Dockerfile
 # Group 4 is optional
+# Group 5 must be synced with requirements for tutorials
 RUN apt-get update && apt-get install -y \
     build-essential \
     libgomp1 \
@@ -23,22 +25,27 @@ RUN apt-get update && apt-get install -y \
     \
     less \
     man \
-    vim
+    vim \
+    \
+    libssl-dev
 
-WORKDIR /mnt
+COPY dist/brainiak-* /mnt/brainiak
+
+WORKDIR /mnt/brainiak
+
+COPY tutorials/tutorials tutorials
 
 RUN set -e \
-    && python3 -m pip install --user -U pip \
-    && python3 -m pip install -U brainiak \
-    && python3 -m pip download --no-deps --no-binary :all: brainiak \
-    && export BRAINIAK_VERSION=$(basename brainiak-* .tar.gz | cut -b 10-) \
-    && tar -xf brainiak-*.tar.gz \
-    && for example in brainiak-$BRAINIAK_VERSION/examples/*/requirements.txt; \
+    && python3 -m pip install --user -U "pip<10" \
+    && python3 -m pip install --user -U . \
+    && python3 -m pip install --user -U -r tutorials/requirements.txt \
+    && for example in examples/*/requirements.txt; \
         do python3 -m pip install --user -U -r $example ; done
 
 RUN echo PATH=\"\$HOME/.local/bin:\$PATH\" >> $HOME/.profile \
     && echo "shell -bash" >> ~/.screenrc
 
-EXPOSE 8888
+EXPOSE 8899
 
 ENTRYPOINT ["/bin/bash", "-l"]
+CMD ["tutorials/run_jupyter_docker.sh"]


### PR DESCRIPTION
Move to Ubuntu 18.04 for Python 3.6, required for tutorials.