### PR TITLE
Allowing the `sl_rad` parameter in searchlight to be 0

### DIFF
--- a/brainiak/searchlight/searchlight.py
+++ b/brainiak/searchlight/searchlight.py
@@ -155,6 +155,8 @@ class Searchlight:
     """
     def __init__(self, sl_rad=1, max_blk_edge=10, shape=Cube,
                  min_active_voxels_proportion=0):
+        assert sl_rad >= 0, 'sl_rad should not be negative'
+        assert max_blk_edge > 0, 'max_blk_edge should be positive'
         self.sl_rad = sl_rad
         self.max_blk_edge = max_blk_edge
         self.min_active_voxels_proportion = min_active_voxels_proportion
@@ -534,9 +536,11 @@ def _singlenode_searchlight(l, msk, mysl_rad, bcast_var, extra_params):
     voxel_fn = extra_params[0]
     shape_mask = extra_params[1]
     min_active_voxels_proportion = extra_params[2]
-    outmat = np.empty(msk.shape, dtype=np.object)[mysl_rad:-mysl_rad,
-                                                  mysl_rad:-mysl_rad,
-                                                  mysl_rad:-mysl_rad]
+    outmat = np.empty(msk.shape, dtype=np.object)
+    if mysl_rad > 0:
+        outmat = outmat[mysl_rad:-mysl_rad,
+                        mysl_rad:-mysl_rad,
+                        mysl_rad:-mysl_rad]
     for i in range(0, outmat.shape[0]):
         for j in range(0, outmat.shape[1]):
             for k in range(0, outmat.shape[2]):

--- a/tests/searchlight/test_searchlight.py
+++ b/tests/searchlight/test_searchlight.py
@@ -265,7 +265,6 @@ def test_correctness():  # noqa: C901
         sl.distribute(data, mask)
         sl.broadcast(mask)
         global_outputs = sl.run_block_function(block_test_sfn)
-        print(global_outputs)
         if rank == 0:
             for d0 in range(rad, global_outputs.shape[0]-rad):
                 for d1 in range(rad, global_outputs.shape[1]-rad):

--- a/tests/searchlight/test_searchlight.py
+++ b/tests/searchlight/test_searchlight.py
@@ -206,7 +206,10 @@ def voxel_test_sfn(l, msk, myrad, bcast):
 def block_test_sfn(l, msk, myrad, bcast_var, extra_params):
     outmat = l[0][:, :, :, 0]
     outmat[~msk] = None
-    return outmat[myrad:-myrad, myrad:-myrad, myrad:-myrad]
+    if myrad == 0:
+        return outmat
+    else:
+        return outmat[myrad:-myrad, myrad:-myrad, myrad:-myrad]
 
 
 def test_correctness():  # noqa: C901
@@ -262,7 +265,7 @@ def test_correctness():  # noqa: C901
         sl.distribute(data, mask)
         sl.broadcast(mask)
         global_outputs = sl.run_block_function(block_test_sfn)
-
+        print(global_outputs)
         if rank == 0:
             for d0 in range(rad, global_outputs.shape[0]-rad):
                 for d1 in range(rad, global_outputs.shape[1]-rad):
@@ -286,6 +289,7 @@ def test_correctness():  # noqa: C901
         block_test(data, mask, max_blk_edge, rad)
 
     do_test(dim0=7, dim1=5, dim2=9, ntr=5, nsubj=1, max_blk_edge=4, rad=1)
+    do_test(dim0=7, dim1=5, dim2=9, ntr=5, nsubj=1, max_blk_edge=4, rad=0)
     do_test(dim0=7, dim1=5, dim2=9, ntr=5, nsubj=5, max_blk_edge=4, rad=1)
     do_test(dim0=1, dim1=5, dim2=9, ntr=5, nsubj=5, max_blk_edge=4, rad=1)
     do_test(dim0=0, dim1=10, dim2=8, ntr=5, nsubj=5, max_blk_edge=4, rad=1)

--- a/tests/searchlight/test_searchlight.py
+++ b/tests/searchlight/test_searchlight.py
@@ -265,6 +265,7 @@ def test_correctness():  # noqa: C901
         sl.distribute(data, mask)
         sl.broadcast(mask)
         global_outputs = sl.run_block_function(block_test_sfn)
+
         if rank == 0:
             for d0 in range(rad, global_outputs.shape[0]-rad):
                 for d1 in range(rad, global_outputs.shape[1]-rad):


### PR DESCRIPTION
There are use cases in which we want to do the same processing on all voxels and want to use MPI to parallelize this. In this case, the searchlight has the size of 1, and it corresponds to `sl_rad = 0` when initializing `SearchLight`. But the current implementation will distribute an empty array to each worker if we set `sl_rad = 0`. The consequence is that nothing gets computed for each voxel. This PR fixes this bug.