### PR TITLE
dev: Add MPICH as explicit dependency for Conda

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - python
     - setuptools
     - pip
+    - mpich
     - openmp
     {% for req in data.get('setup_requires', [])
         if req not in conda_package_nonexistent -%}
@@ -48,6 +49,7 @@ requirements:
 
   run:
     - python
+    - mpich
     - openmp
     {% for req in data.get('install_requires', [])
         if req not in conda_package_nonexistent -%}


### PR DESCRIPTION
Conda defaults to OpenMPI, which is causing problems in Travis:
https://travis-ci.org/brainiak/brainiak/jobs/609792226