### PR TITLE
dev: Add wheel dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,8 @@ setup(
         'pybind11>=1.7',
         'psutil',
         'nibabel',
-        'joblib'
+        'joblib',
+        'wheel',  # See https://github.com/astropy/astropy-helpers/issues/501
     ],
     author='Princeton Neuroscience Institute and Intel Corporation',
     author_email='mihai.capota@intel.com',


### PR DESCRIPTION
Required by a change in Setuptools 42. See also:
https://github.com/astropy/astropy-helpers/issues/501