### PR TITLE
dev: Pin scikit-learn <0.22 to fix fcma test

### DIFF
--- a/.conda/bin/jenkins-server-customization
+++ b/.conda/bin/jenkins-server-customization
@@ -3,5 +3,5 @@
 
 # TensorFlow 2.0 breaks Pymanopt:
 # https://github.com/pymanopt/pymanopt/issues/86
-conda install --yes mpi4py tensorflow\<2 scipy\<1.3 numpy\<1.17
+conda install --yes mpi4py mpich\<3.3 tensorflow\<2 scipy\<1.3 numpy\<1.17
 module unload gcc

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ setup(
     use_scm_version=True,
     setup_requires=[
         'cython',
-        'numpy',
+        'numpy<1.17',
         'pybind11>=1.7',
         'setuptools_scm',
     ],
@@ -128,7 +128,7 @@ setup(
         'nitime',
         # https://github.com/numpy/numpy/issues/14189
         'numpy<1.17',
-        'scikit-learn[alldeps]>=0.18',
+        'scikit-learn[alldeps]>=0.18,<0.22',
         # See https://github.com/scipy/scipy/pull/8082
         # and https://github.com/pymanopt/pymanopt/issues/77
         'scipy!=1.0.0,<1.3.0',


### PR DESCRIPTION
See issue #448.

Also, pin NumPy in `setup_requires` as well.