### PR TITLE
dev: Unpin Sphinx

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -196,4 +196,4 @@ pseudoxml:
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
 
 apidoc:
-	sphinx-apidoc -f -M -o . ../brainiak
+	sphinx-apidoc -f -M -o . ../brainiak ../brainiak/fcma/cython_blas.*

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ flake8-print
 mypy
 restructuredtext-lint
 setuptools_scm
-sphinx<2.3  # Pending release of https://github.com/sphinx-doc/sphinx/pull/6987
+sphinx
 sphinx_rtd_theme
 towncrier
 


### PR DESCRIPTION
The latest Sphinx version would include the FCMA BLAS extension in the
documentation, but that is not part of the BrainIAK API, so excluding.