### PR TITLE
dev: Rename ambiguous variables

### DIFF
--- a/brainiak/fcma/mvpa_voxelselector.py
+++ b/brainiak/fcma/mvpa_voxelselector.py
@@ -31,18 +31,18 @@ __all__ = [
 ]
 
 
-def _sfn(l, mask, myrad, bcast_var):
+def _sfn(data, mask, myrad, bcast_var):
     """Score classifier on searchlight data using cross-validation.
 
     The classifier is in `bcast_var[2]`. The labels are in `bast_var[0]`. The
     number of cross-validation folds is in `bast_var[1].
     """
     clf = bcast_var[2]
-    data = l[0][mask, :].T
+    masked_data = data[0][mask, :].T
     # print(l[0].shape, mask.shape, data.shape)
     skf = model_selection.StratifiedKFold(n_splits=bcast_var[1],
                                           shuffle=False)
-    accuracy = np.mean(model_selection.cross_val_score(clf, data,
+    accuracy = np.mean(model_selection.cross_val_score(clf, masked_data,
                                                        y=bcast_var[0],
                                                        cv=skf,
                                                        n_jobs=1))

--- a/brainiak/funcalign/sssrm.py
+++ b/brainiak/funcalign/sssrm.py
@@ -51,6 +51,12 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
+# FIXME workaround for Theano failure on macOS Conda builds
+# https://travis-ci.org/github/brainiak/brainiak/jobs/689445834#L1414
+# Inspired by workaround from PyMC3
+# https://github.com/pymc-devs/pymc3/pull/3767
+theano.config.gcc.cxxflags = "-Wno-c++11-narrowing"
+
 
 class SSSRM(BaseEstimator, ClassifierMixin, TransformerMixin):
     """Semi-Supervised Shared Response Model (SS-SRM)

--- a/brainiak/searchlight/searchlight.py
+++ b/brainiak/searchlight/searchlight.py
@@ -522,7 +522,7 @@ class Searchlight:
         return block_fn_result
 
 
-def _singlenode_searchlight(l, msk, mysl_rad, bcast_var, extra_params):
+def _singlenode_searchlight(data, msk, mysl_rad, bcast_var, extra_params):
     """Run searchlight function on block data in parallel.
 
     `extra_params` contains:
@@ -554,7 +554,7 @@ def _singlenode_searchlight(l, msk, mysl_rad, bcast_var, extra_params):
                         or np.count_nonzero(voxel_fn_mask) / voxel_fn_mask.size
                             > min_active_voxels_proportion):
                         outmat[i, j, k] = voxel_fn(
-                            [ll[searchlight_slice] for ll in l],
+                            [subject[searchlight_slice] for subject in data],
                             msk[searchlight_slice] * shape_mask,
                             mysl_rad,
                             bcast_var)

--- a/brainiak/utils/utils.py
+++ b/brainiak/utils/utils.py
@@ -149,7 +149,7 @@ def sumexp_stable(data):
     return result_sum, max_value, result_exp
 
 
-def concatenate_not_none(l, axis=0):
+def concatenate_not_none(data, axis=0):
     """Construct a numpy array by stacking not-None arrays in a list
 
     Parameters
@@ -171,13 +171,13 @@ def concatenate_not_none(l, axis=0):
     """
     # Get the indexes of the arrays in the list
     mask = []
-    for i in range(len(l)):
-        if l[i] is not None:
+    for i in range(len(data)):
+        if data[i] is not None:
             mask.append(i)
 
     # Concatenate them
-    l_stacked = np.concatenate([l[i] for i in mask], axis=axis)
-    return l_stacked
+    stacked = np.concatenate([data[i] for i in mask], axis=axis)
+    return stacked
 
 
 def cov2corr(cov):

--- a/tests/searchlight/test_searchlight.py
+++ b/tests/searchlight/test_searchlight.py
@@ -24,7 +24,7 @@ from brainiak.searchlight.searchlight import Diamond, Ball
 """
 
 
-def cube_sfn(l, msk, myrad, bcast_var):
+def cube_sfn(data, msk, myrad, bcast_var):
     if np.all(msk) and np.any(msk):
         return 1.0
     return None
@@ -90,7 +90,7 @@ def test_searchlight_with_cube_poolsize_1():
                     assert global_outputs[i, j, k] is None
 
 
-def diamond_sfn(l, msk, myrad, bcast_var):
+def diamond_sfn(data, msk, myrad, bcast_var):
     assert not np.any(msk[~Diamond(3).mask_])
     if np.all(msk[Diamond(3).mask_]):
         return 1.0
@@ -127,7 +127,7 @@ def test_searchlight_with_diamond():
                     assert global_outputs[i, j, k] is None
 
 
-def ball_sfn(l, msk, myrad, bcast_var):
+def ball_sfn(data, msk, myrad, bcast_var):
     x, y, z = np.mgrid[-myrad:myrad+1, -myrad:myrad+1, -myrad:myrad+1]
     correct_mask = np.square(x) + np.square(y) + np.square(z) <= myrad ** 2
     assert not np.any(msk[~Ball(3).mask_])
@@ -174,10 +174,10 @@ def test_instantiate():
     assert sl
 
 
-def voxel_test_sfn(l, msk, myrad, bcast):
+def voxel_test_sfn(data, msk, myrad, bcast):
     rad = bcast.rad
     # Check each point
-    for subj in l:
+    for subj in data:
         for _tr in range(subj.shape[3]):
             tr = subj[:, :, :, _tr]
             midpt = tr[rad, rad, rad]
@@ -189,7 +189,7 @@ def voxel_test_sfn(l, msk, myrad, bcast):
                                                         d2-rad, 0]))
 
     # Determine midpoint
-    midpt = l[0][rad, rad, rad, 0]
+    midpt = data[0][rad, rad, rad, 0]
     midpt = (midpt[0], midpt[1], midpt[2])
 
     for d0 in range(msk.shape[0]):
@@ -203,8 +203,8 @@ def voxel_test_sfn(l, msk, myrad, bcast):
     return midpt
 
 
-def block_test_sfn(l, msk, myrad, bcast_var, extra_params):
-    outmat = l[0][:, :, :, 0]
+def block_test_sfn(data, msk, myrad, bcast_var, extra_params):
+    outmat = data[0][:, :, :, 0]
     outmat[~msk] = None
     if myrad == 0:
         return outmat


### PR DESCRIPTION
The renames do not affect the API, except for `concatenate_not_none`,
where the rename actually makes the code agree to the existing
documentation.

The existing variable names caused errors after an update of
Pycodestyle in Flake8:
https://github.com/brainiak/brainiak/pull/464
https://github.com/PyCQA/pycodestyle/pull/853
https://gitlab.com/pycqa/flake8/-/merge_requests/418