### PR TITLE
Update ISC permutation doc to clarify pairwise groups

### DIFF
--- a/brainiak/isc.py
+++ b/brainiak/isc.py
@@ -1060,8 +1060,8 @@ def permutation_isc(iscs, group_assignment=None, pairwise=False,  # noqa: C901
     leave-one-out approach, ISC values for two groups should be stacked
     along first dimension (vertically) and a group_assignment list (or 1d
     array) of same length as the number of subjects should be provided to
-    indicate groups. In the pairwise approach, pairwise ISCs should be
-    computed the across both groups at once; i.e. the pairwise ISC matrix
+    indicate groups. In the pairwise approach, pairwise ISCs should have
+    been computed across both groups at once; i.e. the pairwise ISC matrix
     should be shaped N x N where N is the total number of subjects across
     both groups, and should contain between-group ISC pairs. Pairwise ISC
     input should correspond to the vectorized upper triangle of the square

--- a/brainiak/isc.py
+++ b/brainiak/isc.py
@@ -19,7 +19,7 @@ analyses (e.g., intersubject funtional correlations; ISFC), as well
 as statistical tests designed specifically for ISC analyses.
 
 The implementation is based on the work in [Hasson2004]_, [Kauppi2014]_,
-[Simony2016]_, and [Chen2016]_.
+[Simony2016]_, [Chen2016]_, and [Nastase2019]_.
 
 .. [Chen2016] "Untangling the relatedness among correlations, part I:
    nonparametric approaches to inter-subject correlation analysis at the
@@ -41,6 +41,11 @@ The implementation is based on the work in [Hasson2004]_, [Kauppi2014]_,
    during narrative comprehension.", E. Simony, C. J. Honey, J. Chen, O.
    Lositsky, Y. Yeshurun, A. Wiesel, U. Hasson, 2016, Nature Communications,
    7, 12141. https://doi.org/10.1038/ncomms12141
+
+.. [Nastase2019] "Measuring shared responses across subjects using
+   intersubject correlation." S. A. Nastase, V. Gazzola, U. Hasson,
+   C. Keysers, 2019, Social Cognitive and Affective Neuroscience, 14,
+   667-685. https://doi.org/10.1093/scan/nsz037
 """
 
 # Authors: Sam Nastase, Christopher Baldassano, Qihong Lu,
@@ -405,7 +410,7 @@ def _check_isc_input(iscs, pairwise=False):
     # Check if incoming pairwise matrix is vectorized triangle
     if pairwise:
         try:
-            test_square = squareform(iscs[:, 0])
+            test_square = squareform(iscs[:, 0], force='tomatrix')
             n_subjects = test_square.shape[0]
         except ValueError:
             raise ValueError("For pairwise input, ISCs must be the "
@@ -744,12 +749,12 @@ def bootstrap_isc(iscs, pairwise=False, summary_statistic='median',
             for voxel_iscs in iscs.T:
 
                 # Square the triangle and fill diagonal
-                voxel_iscs = squareform(voxel_iscs)
+                try:
+                    voxel_iscs = squareform(voxel_iscs, force='tomatrix')
+                except ValueError as e:
+                    raise Exception("Pairwise ISC input must be "
+                                    "distance-vector format") from e
                 np.fill_diagonal(voxel_iscs, 1)
-
-                # Check that pairwise ISC matrix is square and symmetric
-                assert voxel_iscs.shape[0] == voxel_iscs.shape[1]
-                assert np.allclose(voxel_iscs, voxel_iscs.T)
 
                 # Shuffle square correlation matrix and get triangle
                 voxel_sample = voxel_iscs[subject_sample, :][:, subject_sample]

--- a/brainiak/isc.py
+++ b/brainiak/isc.py
@@ -749,11 +749,7 @@ def bootstrap_isc(iscs, pairwise=False, summary_statistic='median',
             for voxel_iscs in iscs.T:
 
                 # Square the triangle and fill diagonal
-                try:
-                    voxel_iscs = squareform(voxel_iscs, force='tomatrix')
-                except ValueError as e:
-                    raise Exception("Pairwise ISC input must be "
-                                    "distance-vector format") from e
+                voxel_iscs = squareform(voxel_iscs, force='tomatrix')
                 np.fill_diagonal(voxel_iscs, 1)
 
                 # Shuffle square correlation matrix and get triangle

--- a/brainiak/isc.py
+++ b/brainiak/isc.py
@@ -1056,25 +1056,29 @@ def permutation_isc(iscs, group_assignment=None, pairwise=False,  # noqa: C901
 
     For ISCs from one or more voxels or ROIs, permute group assignments to
     construct a permutation distribution. Input is a list or ndarray of
-    ISCs  for a single voxel/ROI, or an ISCs-by-voxels ndarray. If two groups,
-    ISC values should stacked along first dimension (vertically), and a
-    group_assignment list (or 1d array) of same length as the number of
-    subjects should be provided to indicate groups. If no group_assignment
-    is provided, one-sample test is performed using a sign-flipping procedure.
-    Performs exact test if number of possible permutations (2**N for one-sample
-    sign-flipping, N! for two-sample shuffling) is less than or equal to number
-    of requested permutation; otherwise, performs approximate permutation test
-    using Monte Carlo resampling. ISC values should either be N ISC values for
-    N subjects in the leave-one-out approach (pairwise=False) or N(N-1)/2 ISC
-    values for N subjects in the pairwise approach (pairwise=True). In the
-    pairwise approach, ISC values should correspond to the vectorized upper
-    triangle of a square corrlation matrix (scipy.stats.distance.squareform).
-    Note that in the pairwise approach, group_assignment order should match the
-    row/column order of the subject-by-subject square ISC matrix even though
-    the input ISCs should be supplied as the vectorized upper triangle of the
-    square ISC matrix. Returns the observed ISC and permutation-based p-value
-    (two-tailed test), as well as the permutation distribution of summary
-    statistic. According to Chen et al., 2016, this is the preferred
+    ISCs  for a single voxel/ROI, or an ISCs-by-voxels ndarray. In the
+    leave-one-out approach, ISC values for two groups should be stacked
+    along first dimension (vertically) and a group_assignment list (or 1d
+    array) of same length as the number of subjects should be provided to
+    indicate groups. In the pairwise approach, pairwise ISCs should be
+    computed the across both groups at once; i.e. the pairwise ISC matrix
+    should be shaped N x N where N is the total number of subjects across
+    both groups, and should contain between-group ISC pairs. Pairwise ISC
+    input should correspond to the vectorized upper triangle of the square
+    pairwise ISC correlation matrix containing both groups. In the pairwise
+    approach, group_assignment order should match the row/column order of the
+    subject-by-subject square ISC matrix even though the input ISCs should be
+    supplied as the vectorized upper triangle of the square ISC matrix. If no
+    group_assignment is provided, one-sample test is performed using a sign-
+    flipping procedure. Performs exact test if number of possible permutations
+    (2**N for one-sample sign-flipping, N! for two-sample shuffling) is less
+    than or equal to number of requested permutation; otherwise, performs
+    approximate permutation test using Monte Carlo resampling. ISC values
+    should either be N ISC values for N subjects in the leave-one-out approach
+    (pairwise=False) or N(N-1)/2 ISC values for N subjects in the pairwise
+    approach (pairwise=True). Returns the observed ISC and permutation-based
+    p-value (two-tailed test), as well as the permutation distribution of
+    summary statistic. According to Chen et al., 2016, this is the preferred
     nonparametric approach for controlling false positive rates (FPR) for
     two-sample tests. This approach may yield inflated FPRs for one-sample
     tests.


### PR DESCRIPTION
This addresses the confusion with issue #449 (via @mcdoar9). The documentation was unclear on how to supply pairwise ISCs for two groups to the permutation test. The documentation is now updated to make it more clear that pairwise ISCs must be computed on both groups at once (such that between-group ISCs are included in the pairwise ISC matrix) prior to this ISC matrix being supplied to `permutation_isc`.