### PR TITLE
dev: Unpin Pip, drop Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       dist: xenial
       sudo: required
       language: python
-      python: 3.5
+      python: 3.8
       addons: *linux_addons
 
     - os: osx

--- a/pr-check.sh
+++ b/pr-check.sh
@@ -106,7 +106,7 @@ $activate_venv $venv || {
     exit_with_error "Virtual environment activation failed."
 }
 
-python3 -m pip install -U "pip<10" || \
+python3 -m pip install -U pip || \
     exit_with_error_and_venv "Failed to update Pip."
 
 # install brainiak in editable mode (required for testing)

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,7 @@ setup(
         'cython',
         'numpy!=1.17.*',
         'pybind11>=1.7',
+        'scipy!=1.0.0',
         'setuptools_scm',
     ],
     install_requires=[


### PR DESCRIPTION
Also make SciPy a build dependency, because unpining Pip breaks
the build otherwise.

Python 3.5 is no longer supported by NumPy.