### PR TITLE
change dtype=np.int to dtype=int

### DIFF
--- a/brainiak/funcalign/srm.py
+++ b/brainiak/funcalign/srm.py
@@ -240,8 +240,8 @@ class SRM(BaseEstimator, TransformerMixin):
                     "Not all ranks have same number of subjects")
 
         # Collect size information
-        shape0 = np.zeros((number_subjects,), dtype=np.int)
-        shape1 = np.zeros((number_subjects,), dtype=np.int)
+        shape0 = np.zeros((number_subjects,), dtype=int)
+        shape1 = np.zeros((number_subjects,), dtype=int)
 
         for subject in range(number_subjects):
             if X[subject] is not None:

--- a/examples/fcma/mvpa_voxel_selection.py
+++ b/examples/fcma/mvpa_voxel_selection.py
@@ -87,8 +87,8 @@ if __name__ == '__main__':
         score_volume = np.nan_to_num(score_volume.astype(np.float))
         io.save_as_nifti_file(score_volume, mask_image.affine,
                                    'result_score.nii.gz')
-        seq_volume = np.zeros(mask.shape, dtype=np.int)
-        seq = np.zeros(len(results), dtype=np.int)
+        seq_volume = np.zeros(mask.shape, dtype=int)
+        seq = np.zeros(len(results), dtype=int)
         with open('result_list.txt', 'w') as fp:
             for idx, tuple in enumerate(results):
                 fp.write(str(tuple[0]) + ' ' + str(tuple[1]) + '\n')

--- a/examples/fcma/voxel_selection.py
+++ b/examples/fcma/voxel_selection.py
@@ -89,8 +89,8 @@ if __name__ == '__main__':
         mask = mask_img.get_data().astype(np.bool)
         score_volume = np.zeros(mask.shape, dtype=np.float32)
         score = np.zeros(len(results), dtype=np.float32)
-        seq_volume = np.zeros(mask.shape, dtype=np.int)
-        seq = np.zeros(len(results), dtype=np.int)
+        seq_volume = np.zeros(mask.shape, dtype=int)
+        seq = np.zeros(len(results), dtype=int)
         with open('result_list.txt', 'w') as fp:
             for idx, tuple in enumerate(results):
                 fp.write(str(tuple[0]) + ' ' + str(tuple[1]) + '\n')


### PR DESCRIPTION
In [release 1.20 of numpy](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations), the use of `np.int` was depreciated. Users with numpy>1.19 in their virtual environments will encounter errors due to a few usage of np.int. Per the suggestion, a default way is to change to `dtype=int` from `dtype=np.int`, although what exact type of int will be used depends on the system. However, since most of the experiments won't have subject number more than 2^32 and I suppose it is unlikely that a system defaults to int8. I think leaving it to `dtype=int` should be fine