### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ setup(
         'scikit-learn[alldeps]>=0.18',
         # See https://github.com/scipy/scipy/pull/8082
         'scipy!=1.0.0',
-        'statsmodels',
+        'statsmodels<=0.12.0',
         'pymanopt',
         'theano>=1.0.4',  # See https://github.com/Theano/Theano/pull/6671
         'pybind11>=1.7',


### PR DESCRIPTION
The new versions of statsmodels have broken fmrisim. In particular, they have removed the calls for ARMA models and replaced them with a new ARIMA model. The latest version compatible with fmrisim is 0.12.0