### PR TITLE
Remove quotes from anaconda upload command

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -196,5 +196,5 @@ jobs:
       - name: Upload to Anaconda
         run: |
           export ANACONDA_API_TOKEN=${{ secrets.ANACONDA_TOKEN }}
-          find conda-packages -type f -name "*.tar.bz2" -exec "anaconda upload {}" \;
+          find conda-packages -type f -name "*.tar.bz2" -exec anaconda upload {} \;
 


### PR DESCRIPTION
It seems I forgot to remove quotes from the upload command. I think this should do it.