### PR TITLE
Fix Docker and add v0.12 release notes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 # Group 1 must be synced with README
@@ -30,17 +30,25 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-COPY brainiak-* /mnt/brainiak
+COPY dist/brainiak-* /mnt
+
+WORKDIR /mnt
+
+RUN set -e \
+    && tar -xf brainiak-*.tar.gz \
+    && mv brainiak-*.tar.gz sdist.tar.gz \
+    && mv brainiak-* brainiak
 
 WORKDIR /mnt/brainiak
 
 COPY tutorials/tutorials tutorials
 
 RUN set -e \
-    && python3 -m pip install --user -U pip \
-    && python3 -m pip install --user -U -r tutorials/requirements.txt \
+    && python3 -m pip install --user --break-system-packages -U pip \
+    && python3 -m pip install --user --break-system-packages -U . \
+    && python3 -m pip install --user --break-system-packages -U -r tutorials/requirements.txt \
     && for example in examples/*/requirements.txt; \
-        do python3 -m pip install --user -U -r $example ; done \
+        do python3 -m pip install --user --break-system-packages -U -r $example ; done \
     && rm -rf ~/.cache/pip
 
 RUN echo PATH=\"\$HOME/.local/bin:\$PATH\" >> $HOME/.profile \

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -2,6 +2,32 @@
 
 .. towncrier release notes start
 
+BrainIAK 0.12 (2024-12-24)
+==========================
+
+Features
+--------
+
+- Add support for Windows (`#549 <https://github.com/brainiak/brainiak/issues/549>`_)
+- Publish wheels (`#549 <https://github.com/brainiak/brainiak/issues/549>`_)
+
+Bugfixes
+--------
+
+- Fix Docker image.
+
+Documentation improvements
+--------------------------
+
+- fmrisim: Burn in is removed so that the size of the signal and noise volumes are the same (`#542 <https://github.com/brainiak/brainiak/issues/542>`_)
+
+Deprecations and removals
+-------------------------
+
+- Refactor package to generally recommended src layout (`#549 <https://github.com/brainiak/brainiak/issues/549>`_)
+- Drop support for Python < 3.9 (`#549 <https://github.com/brainiak/brainiak/issues/549>`_)
+
+
 BrainIAK 0.11 (2020-10-14)
 ==========================
 

--- a/README.rst
+++ b/README.rst
@@ -44,14 +44,9 @@ Docker
 You can also test BrainIAK without installing it using Docker::
 
     docker pull brainiak/brainiak
-    docker run -it -p 8888:8888 -v brainiak:/mnt --name demo brainiak/brainiak
+    docker run -it -p 8899:8899 brainiak/brainiak
 
-To run Jupyter notebooks in the running container, try::
-
-    python3 -m notebook --allow-root --no-browser --ip=0.0.0.0
-
-Then visit http://localhost:8888 in your browser and enter the token. Protip:
-run ``screen`` before running the notebook command.
+Jupyter Notebook will start automatically; visit the URL shown in the Docker command output to access it. You can then run the BrainIAK examples or create new notebooks. You can also try a `sample example <http://127.0.0.1:8899/notebooks/examples/funcalign/rsrm_synthetic_reconstruction.ipynb>`_.
 
 Note that we do not support MPI execution using Docker containers and that performance will not be optimal.
 

--- a/examples/funcalign/rsrm_synthetic_reconstruction.ipynb
+++ b/examples/funcalign/rsrm_synthetic_reconstruction.ipynb
@@ -156,13 +156,13 @@
    "outputs": [],
    "source": [
     "fig = plt.figure()\n",
-    "ax = fig.gca(projection='3d')\n",
-    "ax.plot(curve[0, :], curve[1, :], curve[2, :], '-g', label='original', lineWidth=5)\n",
+    "ax = fig.add_subplot(projection='3d')\n",
+    "ax.plot(curve[0, :], curve[1, :], curve[2, :], '-g', label='original', linewidth=5)\n",
     "\n",
     "proj = find_orthogonal_transform(algo_srm.s_, curve)\n",
-    "ax.plot(proj[0, :], proj[1, :], proj[2, :], '-b', label='SRM', lineWidth=3)\n",
+    "ax.plot(proj[0, :], proj[1, :], proj[2, :], '-b', label='SRM', linewidth=3)\n",
     "proj = find_orthogonal_transform(algo_rsrm.r_, curve)\n",
-    "ax.plot(proj[0, :], proj[1, :], proj[2, :], '-r', label='RSRM', lineWidth=3)\n",
+    "ax.plot(proj[0, :], proj[1, :], proj[2, :], '-r', label='RSRM', linewidth=3)\n",
     "plt.legend()"
    ]
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,11 @@ write_to = "src/brainiak/_version.py"
 minimum-version = "0.4"
 build-dir = "build/{wheel_tag}"
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-sdist.include = ["src/brainiak/_version.py", "src/brainiak/utils/sim_parameters"]
+sdist.include = [
+    "tests/io/data/*",
+    "src/brainiak/_version.py",
+    "src/brainiak/utils/sim_parameters",
+]
 cmake.build-type = "Release"
 
 [tool.cibuildwheel]


### PR DESCRIPTION
Install from sdist in Dockerfile.

Update Matplotlib API in notebook example used to showcase Docker at brainiak.org.

Fix Docker instructions in README.

Include test data in sdist.