### PR TITLE
docs: document return value of run_block_function

### DIFF
--- a/src/brainiak/searchlight/searchlight.py
+++ b/src/brainiak/searchlight/searchlight.py
@@ -426,6 +426,15 @@ class Searchlight:
             Maximum number of processes running the block function in parallel.
             If None, number of available hardware threads, considering cpusets
             restrictions.
+
+        Returns
+        -------
+
+        An object array with the same shape as the mask, where each voxel
+        contains the 3D array returned by the block function for the block
+        containing that voxel, with the padding removed. The array is
+        populated only on the root rank; on other ranks it is returned
+        unpopulated.
         """
         rank = self.comm.rank
 


### PR DESCRIPTION
Fixes #155

Adds the missing `Returns` section to the `run_block_function` docstring in `brainiak/searchlight/searchlight.py`. `run_searchlight` already documents its return value.